### PR TITLE
Simplify Dockerfile and move graalvm build to separate file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,15 @@
-# this dockerfile and the associated compilation steps are
-# highly inspired by babashka's compilation process.
-#
-# See below for more details:
-#   https://github.com/babashka/babashka
-FROM clojure:openjdk-11-lein-2.9.6-bullseye AS BASE
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update
-RUN apt install --no-install-recommends -yy curl unzip build-essential zlib1g-dev sudo
-WORKDIR "/opt"
-RUN curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
-RUN tar -xzf graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
-
-ENV GRAALVM_HOME="/opt/graalvm-ce-java11-21.1.0"
-ENV JAVA_HOME="/opt/graalvm-ce-java11-21.1.0/bin"
-ENV PATH="$JAVA_HOME:$PATH"
-ENV IS_STATIC="true"
-ENV USE_MUSL="true"
-
-COPY . .
-RUN ./script/setup-musl
-RUN ./script/uberjar
-RUN ./script/compile
-
 FROM ubuntu:latest
-COPY --from=BASE /opt/lh /usr/local/bin/lh
+WORKDIR /app
+
+RUN apt update && \
+    apt install --no-install-recommends -yy curl unzip ca-certificates
+
+ARG LH_VERSION
+RUN test -n "$LH_VERSION" && \
+    curl -sLO https://github.com/barracudanetworks/lighthouse/releases/download/$LH_VERSION/lighthouse-native-linux-amd64.zip && \
+    unzip lighthouse-native-linux-amd64.zip && \
+    mv lh /usr/local/bin && \
+    rm lighthouse-native-linux-amd64.zip
+
 ENTRYPOINT ["lh"]
 CMD ["--help"]

--- a/Dockerfile-graalvm-build
+++ b/Dockerfile-graalvm-build
@@ -1,0 +1,27 @@
+# this dockerfile and the associated compilation steps are
+# highly inspired by babashka's compilation process.
+#
+# See below for more details:
+#   https://github.com/babashka/babashka
+FROM clojure:openjdk-11-lein-2.9.6-bullseye AS BASE
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update
+RUN apt install --no-install-recommends -yy curl unzip build-essential zlib1g-dev sudo
+WORKDIR "/opt"
+RUN curl -sLO https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
+RUN tar -xzf graalvm-ce-java11-linux-amd64-21.1.0.tar.gz
+
+ENV GRAALVM_HOME="/opt/graalvm-ce-java11-21.1.0"
+ENV JAVA_HOME="/opt/graalvm-ce-java11-21.1.0/bin"
+ENV PATH="$JAVA_HOME:$PATH"
+ENV IS_STATIC="true"
+
+COPY . .
+RUN ./script/uberjar
+RUN ./script/compile
+
+FROM ubuntu:latest
+COPY --from=BASE /opt/lh /usr/local/bin/lh
+ENTRYPOINT ["lh"]
+CMD ["--help"]


### PR DESCRIPTION
The main `Dockerfile` did an entire GraalVM build. This change makes the main `Dockerfile` fetch a binary from Github releases, which are populated with CI, so it will build faster.

The original `Dockerfile` was fixed to work and moved to `Dockerfile-graalvm-build`.